### PR TITLE
Closes #48 Clarify configuration precedence and override rules in docs

### DIFF
--- a/__stash3/Abbreviation.js
+++ b/__stash3/Abbreviation.js
@@ -1,0 +1,47 @@
+/**
+ * @description
+ * Given two strings, `source` and `target`, determine if it's possible to make `source` equal
+ * to `target` You can perform the following operations on the string `source`:
+ * 1. Capitalize zero or more of `source`'s lowercase letters.
+ * 2. Delete all the remaining lowercase letters in `source`.
+ *
+ * Time Complexity: (O(|source|*|target|)) where `|source|` => length of string `source`
+ *
+ * @param {String} source - The string to be transformed.
+ * @param {String} target - The string we want to transform `source` into.
+ * @returns {Boolean} - Whether the transformation is possible.
+ * @see https://www.hackerrank.com/challenges/abbr/problem - Related problem on HackerRank.
+ */
+export const isAbbreviation = (source, target) => {
+  const sourceLength = source.length
+  const targetLength = target.length
+
+  // Initialize a table to keep track of possible abbreviations
+  let canAbbreviate = Array.from({ length: sourceLength + 1 }, () =>
+    Array(targetLength + 1).fill(false)
+  )
+  // Empty strings are trivially abbreviatable
+  canAbbreviate[0][0] = true
+
+  for (let sourceIndex = 0; sourceIndex < sourceLength; sourceIndex++) {
+    for (let targetIndex = 0; targetIndex <= targetLength; targetIndex++) {
+      if (canAbbreviate[sourceIndex][targetIndex]) {
+        // If characters at the current position are equal, move to the next position in both strings.
+        if (
+          targetIndex < targetLength &&
+          source[sourceIndex].toUpperCase() === target[targetIndex]
+        ) {
+          canAbbreviate[sourceIndex + 1][targetIndex + 1] = true
+        }
+        // If the current character in `source` is lowercase, explore two possibilities:
+        // a) Capitalize it (which is akin to "using" it in `source` to match `target`), or
+        // b) Skip it (effectively deleting it from `source`).
+        if (source[sourceIndex] === source[sourceIndex].toLowerCase()) {
+          canAbbreviate[sourceIndex + 1][targetIndex] = true
+        }
+      }
+    }
+  }
+
+  return canAbbreviate[sourceLength][targetLength]
+}

--- a/__stash3/CoinChangeTest.java
+++ b/__stash3/CoinChangeTest.java
@@ -1,0 +1,80 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CoinChangeTest {
+
+    @Test
+    void testChangeBasic() {
+        int amount = 12;
+        int[] coins = {2, 4, 5};
+
+        assertEquals(5, CoinChange.change(coins, amount));
+    }
+
+    @Test
+    void testChangeNoCoins() {
+        int amount = 12;
+        int[] coins = {};
+
+        assertEquals(0, CoinChange.change(coins, amount));
+    }
+
+    @Test
+    void testChangeNoAmount() {
+        int amount = 0;
+        int[] coins = {2, 4, 5};
+
+        assertEquals(1, CoinChange.change(coins, amount));
+    }
+
+    @Test
+    void testChangeImpossibleAmount() {
+        int amount = 3;
+        int[] coins = {2, 4, 5};
+
+        assertEquals(0, CoinChange.change(coins, amount));
+    }
+
+    @Test
+    void testMinimumCoinsBasic() {
+        int amount = 12;
+        int[] coins = {2, 4, 5};
+
+        assertEquals(3, CoinChange.minimumCoins(coins, amount));
+    }
+
+    @Test
+    void testMinimumCoinsNoCoins() {
+        int amount = 12;
+        int[] coins = {};
+
+        assertEquals(Integer.MAX_VALUE, CoinChange.minimumCoins(coins, amount));
+    }
+
+    @Test
+    void testMinimumCoinsNoAmount() {
+        int amount = 0;
+        int[] coins = {2, 4, 5};
+
+        assertEquals(0, CoinChange.minimumCoins(coins, amount));
+    }
+
+    @Test
+    void testMinimumCoinsImpossibleAmount() {
+        int amount = 3;
+        int[] coins = {2, 4, 5};
+
+        assertEquals(Integer.MAX_VALUE, CoinChange.minimumCoins(coins, amount));
+    }
+
+    @Test
+    void testMinimumCoinsExactAmount() {
+        int amount = 10;
+        int[] coins = {1, 5, 10};
+
+        assertEquals(1, CoinChange.minimumCoins(coins, amount));
+    }
+}

--- a/__stash3/MyAtoiTest.java
+++ b/__stash3/MyAtoiTest.java
@@ -1,0 +1,43 @@
+package com.thealgorithms.strings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class MyAtoiTest {
+
+    @ParameterizedTest
+    @CsvSource({"'42', 42", "'   -42', -42", "'4193 with words', 4193", "'words and 987', 0", "'-91283472332', -2147483648", "'21474836460', 2147483647", "'   +123', 123", "'', 0", "'    ', 0", "'-2147483648', -2147483648", "'+2147483647', 2147483647", "'   -0012a42', -12",
+        "'9223372036854775808', 2147483647", "'-9223372036854775809', -2147483648", "'3.14159', 3", "'  -0012', -12", "'  0000000000012345678', 12345678", "'  -0000000000012345678', -12345678", "'  +0000000000012345678', 12345678", "'0', 0", "'+0', 0", "'-0', 0"})
+    void
+    testMyAtoi(String input, int expected) {
+        assertEquals(expected, MyAtoi.myAtoi(input));
+    }
+
+    @Test
+    void testNullInput() {
+        assertEquals(0, MyAtoi.myAtoi(null));
+    }
+
+    @Test
+    void testSinglePlus() {
+        assertEquals(0, MyAtoi.myAtoi("+"));
+    }
+
+    @Test
+    void testSingleMinus() {
+        assertEquals(0, MyAtoi.myAtoi("-"));
+    }
+
+    @Test
+    void testIntegerMinBoundary() {
+        assertEquals(Integer.MIN_VALUE, MyAtoi.myAtoi("-2147483648"));
+    }
+
+    @Test
+    void testIntegerMaxBoundary() {
+        assertEquals(Integer.MAX_VALUE, MyAtoi.myAtoi("2147483647"));
+    }
+}

--- a/__stash3/aliquot_test.go
+++ b/__stash3/aliquot_test.go
@@ -1,0 +1,40 @@
+// aliquotsum_test.go
+// description: Returns s(n)
+// author: Akshay Dubey (https://github.com/itsAkshayDubey)
+// see aliquotsum.go
+
+package math_test
+
+import (
+	"testing"
+
+	"github.com/TheAlgorithms/Go/math"
+)
+
+func TestAliquotSum(t *testing.T) {
+	var tests = []struct {
+		name          string
+		n             int
+		expectedValue int
+		expectedError error
+	}{
+		{"n = 10", 10, 8, nil},
+		{"n = 11", 11, 1, nil},
+		{"n = 1", 1, 0, nil},
+		{"n = -1", -1, 0, math.ErrPosArgsOnly},
+		{"n = 0", 0, 0, math.ErrNonZeroArgsOnly},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := math.AliquotSum(test.n)
+			if result != test.expectedValue || test.expectedError != err {
+				t.Errorf("expected error: %s, got: %s; expected value: %v, got: %v", test.expectedError, err, test.expectedValue, result)
+			}
+		})
+	}
+}
+func BenchmarkAliquotSum(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = math.AliquotSum(65536)
+	}
+}

--- a/__stash3/generateparentheses.ts
+++ b/__stash3/generateparentheses.ts
@@ -1,0 +1,35 @@
+/**
+ * Given a number n pairs of parentheses, generate all combinations of valid parentheses
+ * @param {number} n: Number of given parentheses
+ * @return {string[]} result: Array that contains all valid parentheses
+ * @see https://leetcode.com/problems/generate-parentheses/
+ */
+
+const generateParentheses = (n: number): string[] => {
+  const result: string[] = []
+
+  const solve = (
+    chars: string,
+    openParentheses: number,
+    closedParentheses: number
+  ) => {
+    if (openParentheses === n && closedParentheses === n) {
+      result.push(chars)
+      return
+    }
+
+    if (openParentheses <= n) {
+      solve(chars + '(', openParentheses + 1, closedParentheses)
+    }
+
+    if (closedParentheses < openParentheses) {
+      solve(chars + ')', openParentheses, closedParentheses + 1)
+    }
+  }
+
+  solve('', 0, 0)
+
+  return result
+}
+
+export { generateParentheses }


### PR DESCRIPTION
48 This change exposes retry policy configuration via existing settings. Users can now tune robustness based on their environment. Defaults remain conservative.