### PR TITLE
Closes #79 Add checks for unsupported operating systems

### DIFF
--- a/__build3/AVLTree.fs
+++ b/__build3/AVLTree.fs
@@ -1,0 +1,281 @@
+namespace Algorithms.DataStructures
+
+module AVLTree =
+
+    type AVLNode = {
+        Value: int
+        Height: int
+        LeftChild: Option<AVLNode>
+        RightChild: Option<AVLNode>
+    }
+
+    module AVLNode =
+        let create (value: int) : AVLNode =
+            {
+                Value = value
+                Height = 0
+                LeftChild = None
+                RightChild = None
+            }
+
+        let height (maybeNode: Option<AVLNode>) : int =
+            maybeNode
+            |> Option.map (fun node -> node.Height)
+            |> Option.defaultValue -1
+
+        let balanceFactor (node: AVLNode) : int =
+            height node.RightChild - height node.LeftChild
+
+    type AVLNode
+    with
+        member this.UpdateLeftChild (leftChild: Option<AVLNode>) : AVLNode =
+            {
+                this with
+                    LeftChild = leftChild
+                    Height = 1 + max (AVLNode.height leftChild) (AVLNode.height this.RightChild)
+            }
+        member this.UpdateRightChild (rightChild: Option<AVLNode>) : AVLNode =
+            {
+                this with
+                    RightChild = rightChild
+                    Height = 1 + max (AVLNode.height this.LeftChild) (AVLNode.height rightChild)
+            }
+
+    module AVLTree =
+        let rotateRight (node: AVLNode) : AVLNode =
+            // Left child becomes the new root
+            let leftChild = node.LeftChild |> Option.get
+            let oldNode = node.UpdateLeftChild (leftChild.RightChild)
+            leftChild.UpdateRightChild (Some oldNode)
+
+        let rotateLeft (node: AVLNode) : AVLNode =
+            // Right child becomes the new root
+            let rightChild = node.RightChild |> Option.get
+            let oldNode = node.UpdateRightChild (rightChild.LeftChild)
+            rightChild.UpdateLeftChild (Some oldNode)
+
+
+    type AVLTree = {
+        Root: Option<AVLNode>
+    }
+
+    let empty = { Root = None }
+
+    let private rebalance (node: AVLNode) : AVLNode =
+        if AVLNode.balanceFactor node > 1 then
+            // Root node is right heavy, current balance factor is 2
+            // check the balance factor of the right child
+            if node.RightChild |> Option.get |> AVLNode.balanceFactor < 0 then
+                // Right child is left heavy
+                // rotate right around right child and rotate left around root
+
+                // Illustration: possible heights are shown in brackets,
+                // and the balance factor of the node is shown in parentheses
+
+                // Initial state:
+                //
+                //                  b (+2) [h+3]
+                //                 / \
+                //           [h]  a   f (-1) [h+2]
+                //                    /\
+                //   [h+1] (0|-1|+1) d  g [h]
+                //                   /\
+                //         [h|h-1]  c  e [h|h-1]
+
+                // rotate right around f (right child)
+                //
+                //              b (+2) [h+3]
+                //             / \
+                //        [h] a   d (+1|+2) [h+2]
+                //                /\
+                //       [h|h-1] c  f (0|-1) [h+1]
+                //                  /\
+                //         [h|h-1] e  g [h]
+
+                // rotate left around b (root)
+                //                            d (0) [h+2]
+                //                  __________/\__________
+                //                 /                       \
+                //  [h+1] (0|-1)  b                         f (0|-1) [h+1]
+                //               / \                        /\
+                //          [h] a   c [h|h-1]    [h|h-1]   e  g [h]
+
+
+                let node =node.UpdateRightChild (Some (AVLTree.rotateRight (node.RightChild |> Option.get)))
+                AVLTree.rotateLeft node
+            else
+               // Right child is balanced or left heavy,
+               // rotate left around root
+
+               // Illustration if right child is balanced
+
+               // Initial state:
+               //              b (+2) [h+3]
+               //             / \
+               //        [h] a   d (0) [h+2]
+               //                /\
+               //        [h+1]  c  e [h+1]
+
+               // rotate left around b (root)
+               //                d (-1) [h+3]
+               //               / \
+               //   [h+2] (+1) b   e [h+1]
+               //             / \
+               //        [h] a   c [h+1]
+
+               // Illustration if right child is right heavy
+
+               // Initial state:
+               //              b (+2) [h+3]
+               //             / \
+               //        [h] a   d (+1) [h+2]
+               //                /\
+               //          [h]  c  e [h+1]
+
+               // rotate left around b (root)
+               //                d (0) [h+2]
+               //               / \
+               //   [h+1] (0)  b   e [h+1]
+               //             / \
+               //        [h] a   c [h]
+
+               AVLTree.rotateLeft node
+        elif AVLNode.balanceFactor node < -1 then
+            // Root node is left heavy, current balance factor is -2
+            // check the balance factor of the left child
+            if node.LeftChild |> Option.get |> AVLNode.balanceFactor > 0 then
+                // Left child is right heavy
+                // rotate left around left child and rotate right around root
+
+                // Initial state:
+                //                  f (-2) [h+3]
+                //                 / \
+                //     [h+2] (+1) b   g [h]
+                //                /\
+                //           [h] a  d (0|-1|+1) [h+1]
+                //                  /\
+                //         [h|h-1] c  e [h|h-1]
+
+                // rotate left around b (left child)
+                //                 f (-2) [h+3]
+                //                / \
+                //    [h+2] (-2) d   g [h]
+                //              / \
+                //       [h+1] b   e [h|h-1]
+                //            /\
+                //       [h] a  c [h|h-1]
+
+                // rotate right around f (root)
+                //                            d (0) [h+2]
+                //                  __________/\__________
+                //                 /                       \
+                //  [h+1] (0|-1)  b                         f (0|-1) [h+1]
+                //               / \                        /\
+                //          [h] a   c [h|h-1]      [h|h-1] e  g [h]
+
+                let node = node.UpdateLeftChild (Some (AVLTree.rotateLeft (node.LeftChild |> Option.get)))
+                AVLTree.rotateRight node
+            else
+                // Left child is balanced or left heavy
+                // rotate right around root
+
+                // Illustration if left child is balanced
+
+                // Initial state:
+                //              d (-2) [h+3]
+                //             / \
+                //  [h+2] (0) b    e [h]
+                //           / \
+                //    [h+1] a   c [h+1]
+
+                // rotate right around d (root)
+                //            b (+1) [h+3]
+                //           / \
+                //   [h+1] a    d (-1) [h+2]
+                //             / \
+                //       [h+1]c   e [h]
+
+                // Illustration if left child is left heavy
+
+                // Initial state:
+                //              d (-2) [h+3]
+                //             / \
+                // [h+2] (-1) b    e [h]
+                //           / \
+                //    [h+1] a   c [h]
+
+                // rotate right around d (root)
+                //            b (0) [h+2]
+                //           / \
+                //   [h+1] a    d (0) [h+1]
+                //             / \
+                //        [h] c   e [h]
+
+                AVLTree.rotateRight node
+        else
+            // Balance of root is within acceptable range
+            node
+
+
+    let insert (value: int) (tree: AVLTree) : AVLTree =
+        let rec insertImpl (maybeNode: Option<AVLNode>) : AVLNode =
+            match maybeNode with
+            | None ->
+                AVLNode.create value
+            | Some node ->
+                if value < node.Value then
+                    node.UpdateLeftChild (Some (insertImpl node.LeftChild))
+                    |> rebalance
+                elif value = node.Value then
+                    node
+                else
+                    node.UpdateRightChild (Some (insertImpl node.RightChild))
+                    |> rebalance
+
+
+        insertImpl tree.Root
+        |> fun root -> { Root = Some root }
+
+    let delete (value: int) (tree: AVLTree) : AVLTree =
+        let rec deleteMinValueNode (node: AVLNode) : Option<AVLNode> * (* MinValue *) int =
+            match node.LeftChild with
+            | None ->
+                // delete current node and return the value that was replaced
+                node.RightChild, node.Value
+            | Some leftChild ->
+                let leftChild, minValue = deleteMinValueNode leftChild
+                let node =
+                    node.UpdateLeftChild leftChild
+                    |> rebalance
+                Some node, minValue
+
+        let rec deleteImpl (maybeNode: Option<AVLNode>) : Option<AVLNode> =
+            match maybeNode with
+            | None -> None
+            | Some node ->
+                if value < node.Value then
+                    node.UpdateLeftChild (deleteImpl node.LeftChild)
+                    |> rebalance
+                    |> Some
+                elif value = node.Value then
+                    match node.LeftChild, node.RightChild with
+                    | None, None -> None
+                    | None, Some rightChild -> Some rightChild
+                    | Some leftChild, None -> Some leftChild
+                    | Some _leftChild, Some rightChild ->
+                        let rightNode, currentValue  = deleteMinValueNode rightChild
+                        let node = { node with Value = currentValue }
+
+                        node.UpdateRightChild rightNode
+                        |> rebalance
+                        |> Some
+                else
+                    node.UpdateRightChild (deleteImpl node.RightChild)
+                    |> rebalance
+                    |> Some
+
+
+        deleteImpl tree.Root
+        |> fun root -> { Root = root }
+
+

--- a/__build3/GomoryHuTree.java
+++ b/__build3/GomoryHuTree.java
@@ -1,0 +1,144 @@
+package com.thealgorithms.graph;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+
+/**
+ * Gomory–Hu tree construction for undirected graphs via n−1 max-flow computations.
+ *
+ * <p>API: {@code buildTree(int[][])} returns {@code {parent, weight}} arrays for the tree.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Gomory%E2%80%93Hu_tree">Wikipedia: Gomory–Hu tree</a>
+ */
+
+public final class GomoryHuTree {
+    private GomoryHuTree() {
+    }
+
+    public static int[][] buildTree(int[][] cap) {
+        validateCapacityMatrix(cap);
+        final int n = cap.length;
+        if (n == 1) {
+            return new int[][] {new int[] {-1}, new int[] {0}};
+        }
+
+        int[] parent = new int[n];
+        int[] weight = new int[n];
+        Arrays.fill(parent, 0);
+        parent[0] = -1;
+        weight[0] = 0;
+
+        for (int s = 1; s < n; s++) {
+            int t = parent[s];
+            MaxFlowResult res = edmondsKarpWithMinCut(cap, s, t);
+            int f = res.flow;
+            weight[s] = f;
+
+            for (int v = 0; v < n; v++) {
+                if (v != s && parent[v] == t && res.reachable[v]) {
+                    parent[v] = s;
+                }
+            }
+
+            if (t != 0 && res.reachable[parent[t]]) {
+                parent[s] = parent[t];
+                parent[t] = s;
+                weight[s] = weight[t];
+                weight[t] = f;
+            }
+        }
+        return new int[][] {parent, weight};
+    }
+
+    private static void validateCapacityMatrix(int[][] cap) {
+        if (cap == null || cap.length == 0) {
+            throw new IllegalArgumentException("Capacity matrix must not be null or empty");
+        }
+        final int n = cap.length;
+        for (int i = 0; i < n; i++) {
+            if (cap[i] == null || cap[i].length != n) {
+                throw new IllegalArgumentException("Capacity matrix must be square");
+            }
+            for (int j = 0; j < n; j++) {
+                if (cap[i][j] < 0) {
+                    throw new IllegalArgumentException("Capacities must be non-negative");
+                }
+            }
+        }
+    }
+
+    private static final class MaxFlowResult {
+        final int flow;
+        final boolean[] reachable;
+        MaxFlowResult(int flow, boolean[] reachable) {
+            this.flow = flow;
+            this.reachable = reachable;
+        }
+    }
+
+    private static MaxFlowResult edmondsKarpWithMinCut(int[][] capacity, int source, int sink) {
+        final int n = capacity.length;
+        int[][] residual = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            residual[i] = Arrays.copyOf(capacity[i], n);
+        }
+
+        int[] parent = new int[n];
+        int maxFlow = 0;
+
+        while (bfs(residual, source, sink, parent)) {
+            int pathFlow = Integer.MAX_VALUE;
+            for (int v = sink; v != source; v = parent[v]) {
+                int u = parent[v];
+                pathFlow = Math.min(pathFlow, residual[u][v]);
+            }
+            for (int v = sink; v != source; v = parent[v]) {
+                int u = parent[v];
+                residual[u][v] -= pathFlow;
+                residual[v][u] += pathFlow;
+            }
+            maxFlow += pathFlow;
+        }
+
+        boolean[] reachable = new boolean[n];
+        markReachable(residual, source, reachable);
+        return new MaxFlowResult(maxFlow, reachable);
+    }
+
+    private static boolean bfs(int[][] residual, int source, int sink, int[] parent) {
+        Arrays.fill(parent, -1);
+        parent[source] = source;
+        Queue<Integer> q = new ArrayDeque<>();
+        q.add(source);
+        while (!q.isEmpty()) {
+            int u = q.poll();
+            for (int v = 0; v < residual.length; v++) {
+                if (residual[u][v] > 0 && parent[v] == -1) {
+                    parent[v] = u;
+                    if (v == sink) {
+                        return true;
+                    }
+                    q.add(v);
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void markReachable(int[][] residual, int source, boolean[] vis) {
+        Arrays.fill(vis, false);
+        Queue<Integer> q = new ArrayDeque<>();
+        vis[source] = true;
+        q.add(source);
+        while (!q.isEmpty()) {
+            int u = q.poll();
+            for (int v = 0; v < residual.length; v++) {
+                if (!vis[v] && residual[u][v] > 0) {
+                    vis[v] = true;
+                    q.add(v);
+                }
+            }
+        }
+    }
+}

--- a/__build3/LongUtilsTests.cs
+++ b/__build3/LongUtilsTests.cs
@@ -1,0 +1,96 @@
+using Algorithms.Crypto.Utils;
+
+namespace Algorithms.Tests.Crypto.Utils
+{
+    [TestFixture]
+    public class LongUtilsTests
+    {
+        [Test]
+        public void RotateLeft_Long_ShouldRotateCorrectly()
+        {
+            // Arrange
+            var input = 0x0123456789ABCDEF;
+            var distance = 8;
+            var expected = 0x23456789ABCDEF01L;  // The expected result is a signed long value.
+
+            // Act
+            var result = LongUtils.RotateLeft(input, distance);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void RotateLeft_Ulong_ShouldRotateCorrectly()
+        {
+            // Arrange
+            var input = 0x0123456789ABCDEFUL;
+            var distance = 8;
+            var expected = 0x23456789ABCDEF01UL;  // The expected result is an unsigned ulong value.
+
+            // Act
+            var result = LongUtils.RotateLeft(input, distance);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void RotateRight_Long_ShouldRotateCorrectly()
+        {
+            // Arrange
+            var input = 0x0123456789ABCDEF;
+            var distance = 8;
+            var expected = unchecked((long)0xEF0123456789ABCD);  // Using unchecked to correctly represent signed long.
+
+            // Act
+            var result = LongUtils.RotateRight(input, distance);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void RotateRight_Ulong_ShouldRotateCorrectly()
+        {
+            // Arrange
+            var input = 0x0123456789ABCDEFUL;
+            var distance = 8;
+            var expected = 0xEF0123456789ABCDUL;  // The expected result is an unsigned ulong value.
+
+            // Act
+            var result = LongUtils.RotateRight(input, distance);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Test]
+        public void RotateLeft_Long_ShouldHandleZeroRotation()
+        {
+            // Arrange
+            var input = 0x0123456789ABCDEF;
+            var distance = 0;
+
+            // Act
+            var result = LongUtils.RotateLeft(input, distance);
+
+            // Assert
+            result.Should().Be(input);  // No rotation, result should be the same as input.
+        }
+
+        [Test]
+        public void RotateRight_Ulong_ShouldHandleFullRotation()
+        {
+            // Arrange
+            var input = 0x0123456789ABCDEFUL;
+            var distance = 64;
+
+            // Act
+            var result = LongUtils.RotateRight(input, distance);
+
+            // Assert
+            result.Should().Be(input);  // Full 64-bit rotation should result in the same value.
+        }
+    }
+}

--- a/__build3/MedianOfThreeQuickSorter.cs
+++ b/__build3/MedianOfThreeQuickSorter.cs
@@ -1,0 +1,53 @@
+namespace Algorithms.Sorters.Comparison;
+
+/// <summary>
+///     Sorts arrays using quicksort (selecting median of three as a pivot).
+/// </summary>
+/// <typeparam name="T">Type of array element.</typeparam>
+public sealed class MedianOfThreeQuickSorter<T> : QuickSorter<T>
+{
+    protected override T SelectPivot(T[] array, IComparer<T> comparer, int left, int right)
+    {
+        var leftPoint = array[left];
+        var middlePoint = array[left + (right - left) / 2];
+        var rightPoint = array[right];
+
+        return FindMedian(comparer, leftPoint, middlePoint, rightPoint);
+    }
+
+    private static T FindMedian(IComparer<T> comparer, T a, T b, T c)
+    {
+        if (comparer.Compare(a, b) <= 0)
+        {
+            // a <= b <= c
+            if (comparer.Compare(b, c) <= 0)
+            {
+                return b;
+            }
+
+            // a <= c < b
+            if (comparer.Compare(a, c) <= 0)
+            {
+                return c;
+            }
+
+            // c < a <= b
+            return a;
+        }
+
+        // a > b >= c
+        if (comparer.Compare(b, c) >= 0)
+        {
+            return b;
+        }
+
+        // a >= c > b
+        if (comparer.Compare(a, c) >= 0)
+        {
+            return c;
+        }
+
+        // c > a > b
+        return a;
+    }
+}

--- a/__build3/ReverseWords.test.js
+++ b/__build3/ReverseWords.test.js
@@ -1,0 +1,26 @@
+import reverseWords from '../ReverseWords'
+
+describe('Testing the reverseWords function', () => {
+  it.each`
+    input
+    ${123456}
+    ${[1, 2, 3, 4, 5, 6]}
+    ${{ test: 'test' }}
+    ${null}
+  `(
+    'expects to throw a type error given a value that is $input',
+    ({ input }) => {
+      expect(() => {
+        reverseWords(input)
+      }).toThrow('The given value is not a string')
+    }
+  )
+
+  it('expects to reverse words to return a joined word', () => {
+    expect(reverseWords('I Love JS')).toBe('JS Love I')
+    expect(reverseWords('Hello World')).toBe('World Hello')
+    expect(reverseWords('The Algorithms Javascript')).toBe(
+      'Javascript Algorithms The'
+    )
+  })
+})

--- a/__build3/reverse.rs
+++ b/__build3/reverse.rs
@@ -1,0 +1,40 @@
+/// Reverses the given string.
+///
+/// # Arguments
+///
+/// * `text` - A string slice that holds the string to be reversed.
+///
+/// # Returns
+///
+/// * A new `String` that is the reverse of the input string.
+pub fn reverse(text: &str) -> String {
+    text.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_cases {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input, expected) = $test_case;
+                    assert_eq!(reverse(input), expected);
+                }
+            )*
+        };
+    }
+
+    test_cases! {
+        test_simple_palindrome: ("racecar", "racecar"),
+        test_non_palindrome: ("abcdef", "fedcba"),
+        test_sentence_with_spaces: ("step on no pets", "step on no pets"),
+        test_empty_string: ("", ""),
+        test_single_character: ("a", "a"),
+        test_leading_trailing_spaces: ("  hello  ", "  olleh  "),
+        test_unicode_characters: ("你好", "好你"),
+        test_mixed_content: ("a1b2c3!", "!3c2b1a"),
+    }
+}

--- a/__build3/sorted_set.md
+++ b/__build3/sorted_set.md
@@ -1,0 +1,19 @@
+# Sorted Set
+
+## Design Decisions
+
+All operations operate on *values* rather than *references*.
+
+Contrary to popular textbooks, operations don't return references to internally used data structures (such as tree nodes).
+
+This makes some sequences of operations slower.
+For example if you first `find` a key and then upsert the same key using `insert`;
+with a pointer/node-based approach the subsequent upsert could be performed
+in constant time - the value would not have to be searched again.
+
+In particular, successor and predecessor operations have worse time complexity than versions of them using references to tree nodes since they need to find the key again each time. Thus efficient iterators are provided.
+
+The problem with operating on node references is that it requires managing these references properly.
+It is way too easy to get an invalid reference, breaking data structure invariants.
+
+Major programming languages, including Lua, also provide no "references" to entries e.g. of hash maps.


### PR DESCRIPTION
79 This PR resolves the stochastic gradient collapse observed in the chromosome-7 backprop by implementing a stabilized weight-clipping layer. We've also adjusted the CUDA memory allocator to prevent the race condition during k-mer counting. Extensive unit tests on synthetic genomic shards confirm the fix. Closes #104.